### PR TITLE
silent_countdown_newmergefix

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1887,6 +1887,7 @@ def on_stage_race():
 
         SOCKET_IO.emit('stage_ready', {
             'hide_stage_timer': MIN != MAX,
+            'silent_countdown': race_format.start_delay_max == 0,
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'pi_starts_at_s': RACE_START
@@ -2392,6 +2393,7 @@ def emit_race_status(**params):
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'hide_stage_timer': race_format.start_delay_min != race_format.start_delay_max,
+            'silent_countdown': race_format.start_delay_max == 0,
             'pi_starts_at_s': RACE_START
         }
     if ('nobroadcast' in params):

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -566,6 +566,7 @@ function timerModel() {
 	this.time_s = false; // simplified relative time in seconds
 	this.count_up = false; // use fixed-length timer
 	this.duration = 0; // fixed-length duration, in seconds
+        this.silent_countdown = false; // eliminate countdown tones
 	this.allow_expire = false; // prevent expire callbacks until timer runs 1 loop
 
 	this.drift_history = [];
@@ -972,7 +973,17 @@ rotorhazard.timer.race.callbacks.step = function(timer){
 	if (timer.warn_until < window.performance.now()) {
 		$('.timing-clock .warning').hide();
 	}
-	if (timer.time_s < 0) {
+	if (timer.time_s < 0 && timer.silent_countdown) {
+            // Be silent during countdown, no tones
+            // Catch this here, as there is logic in general
+            // else block below that will think this is the countdown before
+            // the race ends, and beep! 
+            // 
+            // Also there are some cases where timer.time_s can be less than
+            // -1 even if if min start delay and max start delay are 0 because
+            // of synchronization between the PI and the browser.
+        }
+	else if (timer.time_s < 0) {
 		if (timer.hidden_staging) {
 			// beep every second during staging if timer is hidden
 			if (timer.time_s * 10 % 10 == 0) {

--- a/src/server/templates/race.html
+++ b/src/server/templates/race.html
@@ -17,6 +17,7 @@
 		rotorhazard.race_start_pi = (msg.pi_starts_at_s * 1000); // convert seconds (pi) to millis (JS)
 
 		rotorhazard.timer.race.hidden_staging = Boolean(msg.hide_stage_timer);
+		rotorhazard.timer.race.silent_countdown = Boolean(msg.silent_countdown);
 		rotorhazard.timer.race.count_up = Boolean(msg.race_mode);
 		rotorhazard.timer.race.duration = msg.race_time_sec;
 


### PR DESCRIPTION
Be silent during countdown, no tones if the user specifies max_delay of 0..

Note there are some cases where timer.time_s can be less than -1 even if if min start delay and max start delay are 0 because of synchronization between the PI and the browser.